### PR TITLE
feat: migrate CodeMockup to SolidJS

### DIFF
--- a/src/components/codemockup/CodeMockup.tsx
+++ b/src/components/codemockup/CodeMockup.tsx
@@ -1,0 +1,30 @@
+import {
+  JSX,
+  ParentProps,
+  splitProps,
+  mergeProps,
+  children as getChildren,
+} from "solid-js";
+import { twMerge } from "tailwind-merge";
+
+type AppTheme = "light" | "dark";
+type CodeMockupProps = JSX.HTMLAttributes<HTMLDivElement> & {
+  dataTheme?: AppTheme;
+};
+
+export function CodeMockup(props: ParentProps<CodeMockupProps>): JSX.Element {
+  const merged = mergeProps({ class: "", "aria-label": "Code mockup" }, props);
+  const [local, rest] = splitProps(merged, ["class", "children", "dataTheme"]);
+
+  const resolvedChildren = getChildren(() => local.children);
+
+  return (
+    <div
+      class={twMerge("mockup-code w-full", local.class)}
+      data-theme={local.dataTheme}
+      {...rest}
+    >
+      {resolvedChildren()}
+    </div>
+  );
+}

--- a/src/components/codemockup/CodeMockupLine.tsx
+++ b/src/components/codemockup/CodeMockupLine.tsx
@@ -1,0 +1,67 @@
+import { JSX, splitProps, mergeProps } from "solid-js";
+import clsx from "clsx";
+import { twMerge } from "tailwind-merge";
+
+type ComponentStatus = "info" | "success" | "warning" | "error";
+type AppTheme = "light" | "dark";
+
+type CodeMockupLineProps = JSX.HTMLAttributes<HTMLPreElement> & {
+  dataPrefix?: string | boolean;
+  status?: ComponentStatus;
+  innerProps?: JSX.HTMLAttributes<HTMLElement>;
+  innerRef?: HTMLElement | ((el: HTMLElement) => void);
+  dataTheme?: AppTheme;
+};
+
+export function CodeMockupLine(props: CodeMockupLineProps): JSX.Element {
+  const merged = mergeProps(
+    {
+      dataPrefix: ">",
+      status: null,
+      class: "",
+    },
+    props
+  );
+
+  const [local, rest] = splitProps(merged, [
+    "dataPrefix",
+    "status",
+    "innerProps",
+    "innerRef",
+    "class",
+    "children",
+    "dataTheme",
+  ]);
+
+  const statusClass = () =>
+    twMerge(
+      clsx({
+        "bg-info": local.status === "info",
+        "bg-success": local.status === "success",
+        "bg-warning": local.status === "warning",
+        "bg-error": local.status === "error",
+
+        "text-info-content": local.status === "info",
+        "text-success-content": local.status === "success",
+        "text-warning-content": local.status === "warning",
+        "text-error-content": local.status === "error",
+      }),
+      local.class
+    );
+
+  const prefix = () =>
+    local.dataPrefix !== false ? local.dataPrefix || ">" : undefined;
+
+  return (
+    <pre
+      class={statusClass()}
+      data-prefix={prefix()}
+      data-theme={local.dataTheme}
+      {...rest}
+    >
+      <code {...local.innerProps} ref={local.innerRef}>
+        {local.children}
+      </code>
+    </pre>
+  );
+}

--- a/src/components/codemockup/index.ts
+++ b/src/components/codemockup/index.ts
@@ -1,0 +1,4 @@
+import { CodeMockup } from "./CodeMockup";
+import { CodeMockupLine } from "./CodeMockupLine";
+
+export { CodeMockup, CodeMockupLine };


### PR DESCRIPTION
### API Reference

**CodeMockup**

- dataTheme **|** "light" | "dark" **|** Theme name for Tailwind/daisyUI theme
- 

**CodeMockupLine**

-  dataPrefix **|**  string | boolean  **|**  Controls the prefix character displayed at the beginning of the line. 
-  dataTheme **|** "light" | "dark" **|** Theme name for Tailwind/daisyUI theme
- status **|** 'info' | 'success' | 'warning' | 'error' **|**  Adds contextual styling to the line — including background and text color — based on semantic meaning. Useful for simulating log levels or code execution results.
