### PR TITLE
feat(components): introduce CLASSES sibling-file convention

### DIFF
--- a/src/components/breadcrumbs/Breadcrumbs.classes.ts
+++ b/src/components/breadcrumbs/Breadcrumbs.classes.ts
@@ -1,0 +1,21 @@
+// CSS class contract for Breadcrumbs.
+//
+// Compound shape: this file exports a single CLASSES const whose top-level keys are the
+// component parts (Root, Item). Each part follows the same per-component shape used by
+// Button (`base`, optional `variant`/`size`/`flag`/`color` slots).
+//
+// `base` accepts a single string OR a readonly string[] when the part renders multiple
+// classes unconditionally.
+
+export const CLASSES = {
+  Root: {
+    base: "breadcrumbs",
+  },
+  Item: {
+    // breadcrumbs__item is on the <li>; breadcrumbs__link is on the <a>/<span> inside;
+    // breadcrumbs__separator is on the inner <span>, only rendered when isCurrent is false.
+    // We list it here unconditionally because the safelist is a UNION of "could appear",
+    // and over-including is safe (purges less aggressively) while under-including breaks UI.
+    base: ["breadcrumbs__item", "breadcrumbs__link", "breadcrumbs__separator"],
+  },
+} as const;

--- a/src/components/breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.tsx
@@ -10,6 +10,7 @@ import {
 } from "solid-js";
 import { twMerge } from "tailwind-merge";
 import type { IComponentBaseProps } from "../types";
+import { CLASSES } from "./Breadcrumbs.classes";
 
 /* -------------------------------------------------------------------------------------------------
  * Breadcrumbs Context
@@ -87,7 +88,7 @@ const BreadcrumbsRoot: ParentComponent<BreadcrumbsRootProps> = (props) => {
       <nav
         {...others}
         aria-label="Breadcrumbs"
-        class={twMerge("breadcrumbs", local.class, local.className)}
+        class={twMerge(CLASSES.Root.base, local.class, local.className)}
         data-slot="breadcrumbs"
         data-theme={local.dataTheme}
         style={local.style}
@@ -101,6 +102,8 @@ const BreadcrumbsRoot: ParentComponent<BreadcrumbsRootProps> = (props) => {
 /* -------------------------------------------------------------------------------------------------
  * Breadcrumbs Item
  * -----------------------------------------------------------------------------------------------*/
+const [ITEM_CLASS, LINK_CLASS, SEPARATOR_CLASS] = CLASSES.Item.base;
+
 const BreadcrumbsItem: Component<BreadcrumbsItemProps> = (props) => {
   const [local, others] = splitProps(props, [
     "children",
@@ -117,7 +120,7 @@ const BreadcrumbsItem: Component<BreadcrumbsItemProps> = (props) => {
   return (
     <li
       {...others}
-      class={twMerge("breadcrumbs__item", local.class, local.className)}
+      class={twMerge(ITEM_CLASS, local.class, local.className)}
       data-slot="breadcrumbs-item"
       data-theme={local.dataTheme}
       style={local.style}
@@ -126,7 +129,7 @@ const BreadcrumbsItem: Component<BreadcrumbsItemProps> = (props) => {
         when={local.href && !local.isCurrent}
         fallback={
           <span
-            class="breadcrumbs__link"
+            class={LINK_CLASS}
             data-slot="breadcrumbs-link"
             data-current={local.isCurrent ? "true" : undefined}
             aria-current={local.isCurrent ? "page" : undefined}
@@ -137,14 +140,14 @@ const BreadcrumbsItem: Component<BreadcrumbsItemProps> = (props) => {
       >
         <a
           href={local.href}
-          class="breadcrumbs__link"
+          class={LINK_CLASS}
           data-slot="breadcrumbs-link"
         >
           {local.children}
         </a>
       </Show>
       <Show when={!local.isCurrent}>
-        <span class="breadcrumbs__separator" data-slot="breadcrumbs-separator">
+        <span class={SEPARATOR_CLASS} data-slot="breadcrumbs-separator">
           {ctx.separator() ?? <ChevronRight />}
         </span>
       </Show>

--- a/src/components/button-group/ButtonGroup.classes.ts
+++ b/src/components/button-group/ButtonGroup.classes.ts
@@ -1,0 +1,15 @@
+export const CLASSES = {
+  Root: {
+    base: "button-group",
+    orientation: {
+      horizontal: "button-group--horizontal",
+      vertical: "button-group--vertical",
+    },
+    flag: {
+      fullWidth: "button-group--full-width",
+    },
+  },
+  Separator: {
+    base: "button-group__separator",
+  },
+} as const;

--- a/src/components/button-group/ButtonGroup.tsx
+++ b/src/components/button-group/ButtonGroup.tsx
@@ -4,14 +4,10 @@ import { twMerge } from "tailwind-merge";
 
 import type { ButtonSize, ButtonVariant } from "../button";
 import type { IComponentBaseProps } from "../types";
+import { CLASSES } from "./ButtonGroup.classes";
 import { ButtonGroupContext } from "./context";
 
 export type ButtonGroupOrientation = "horizontal" | "vertical";
-
-const ORIENTATION_CLASS_MAP: Record<ButtonGroupOrientation, string> = {
-  horizontal: "button-group--horizontal",
-  vertical: "button-group--vertical",
-};
 
 export type ButtonGroupRootProps = Omit<JSX.HTMLAttributes<HTMLDivElement>, "children"> &
   IComponentBaseProps & {
@@ -55,9 +51,9 @@ const ButtonGroupRoot: ParentComponent<ButtonGroupRootProps> = (props) => {
       <div
         {...others}
         class={twMerge(
-          "button-group",
-          ORIENTATION_CLASS_MAP[orientation()],
-          local.fullWidth && "button-group--full-width",
+          CLASSES.Root.base,
+          CLASSES.Root.orientation[orientation()],
+          local.fullWidth && CLASSES.Root.flag.fullWidth,
           local.class,
           local.className,
         )}
@@ -81,7 +77,7 @@ const ButtonGroupSeparator: Component<ButtonGroupSeparatorProps> = (props) => {
     <span
       {...others}
       aria-hidden="true"
-      class={twMerge("button-group__separator", local.class, local.className)}
+      class={twMerge(CLASSES.Separator.base, local.class, local.className)}
       data-slot="button-group-separator"
       data-theme={local.dataTheme}
       style={local.style}

--- a/src/components/button/Button.classes.ts
+++ b/src/components/button/Button.classes.ts
@@ -1,0 +1,27 @@
+export const CLASSES = {
+  base: "button",
+  variant: {
+    primary: "button--primary",
+    secondary: "button--secondary",
+    tertiary: "button--tertiary",
+    outline: "button--outline",
+    ghost: "button--ghost",
+    danger: "button--danger",
+    "danger-soft": "button--danger-soft",
+  },
+  size: {
+    sm: "button--sm",
+    md: "button--md",
+    lg: "button--lg",
+  },
+  flag: {
+    isIconOnly: "button--icon-only",
+    fullWidth: "button--full-width",
+  },
+  slot: {
+    spinner: "button__spinner",
+    icon: "button__icon",
+    iconStart: "button__icon--start",
+    iconEnd: "button__icon--end",
+  },
+} as const;

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -2,17 +2,10 @@ import "./Button.css";
 import { Show, splitProps, useContext, type JSX } from "solid-js";
 import { twMerge } from "tailwind-merge";
 import { ButtonGroupContext } from "../button-group/context";
+import { CLASSES } from "./Button.classes";
 
-type ButtonVariant =
-  | "primary"
-  | "secondary"
-  | "tertiary"
-  | "outline"
-  | "ghost"
-  | "danger"
-  | "danger-soft";
-
-type ButtonSize = "sm" | "md" | "lg";
+export type ButtonVariant = keyof typeof CLASSES.variant;
+export type ButtonSize = keyof typeof CLASSES.size;
 
 type ButtonProps = Omit<JSX.ButtonHTMLAttributes<HTMLButtonElement>, "disabled"> & {
   variant?: ButtonVariant;
@@ -24,22 +17,6 @@ type ButtonProps = Omit<JSX.ButtonHTMLAttributes<HTMLButtonElement>, "disabled">
   startIcon?: JSX.Element;
   endIcon?: JSX.Element;
   className?: string;
-};
-
-const VARIANT_CLASS_MAP: Record<ButtonVariant, string> = {
-  primary: "button--primary",
-  secondary: "button--secondary",
-  tertiary: "button--tertiary",
-  outline: "button--outline",
-  ghost: "button--ghost",
-  danger: "button--danger",
-  "danger-soft": "button--danger-soft",
-};
-
-const SIZE_CLASS_MAP: Record<ButtonSize, string> = {
-  sm: "button--sm",
-  md: "button--md",
-  lg: "button--lg",
 };
 
 const Button = (props: ButtonProps): JSX.Element => {
@@ -68,11 +45,11 @@ const Button = (props: ButtonProps): JSX.Element => {
 
   const classes = () =>
     twMerge(
-      "button",
-      VARIANT_CLASS_MAP[variant()],
-      SIZE_CLASS_MAP[size()],
-      local.isIconOnly && "button--icon-only",
-      fullWidth() && "button--full-width",
+      CLASSES.base,
+      CLASSES.variant[variant()],
+      CLASSES.size[size()],
+      local.isIconOnly && CLASSES.flag.isIconOnly,
+      fullWidth() && CLASSES.flag.fullWidth,
       local.class,
       local.className,
     );
@@ -88,16 +65,16 @@ const Button = (props: ButtonProps): JSX.Element => {
       aria-disabled={disabled() ? "true" : "false"}
     >
       <Show when={local.isPending}>
-        <span class="button__spinner" data-slot="spinner" aria-hidden="true" />
+        <span class={CLASSES.slot.spinner} data-slot="spinner" aria-hidden="true" />
       </Show>
       <Show when={local.startIcon}>
-        <span class="button__icon button__icon--start" data-slot="button-start-icon">
+        <span class={twMerge(CLASSES.slot.icon, CLASSES.slot.iconStart)} data-slot="button-start-icon">
           {local.startIcon}
         </span>
       </Show>
       {local.children}
       <Show when={local.endIcon}>
-        <span class="button__icon button__icon--end" data-slot="button-end-icon">
+        <span class={twMerge(CLASSES.slot.icon, CLASSES.slot.iconEnd)} data-slot="button-end-icon">
           {local.endIcon}
         </span>
       </Show>
@@ -107,4 +84,4 @@ const Button = (props: ButtonProps): JSX.Element => {
 
 export default Button;
 
-export type { ButtonProps, ButtonVariant, ButtonSize };
+export type { ButtonProps };

--- a/src/components/card/Card.classes.ts
+++ b/src/components/card/Card.classes.ts
@@ -1,0 +1,24 @@
+export const CLASSES = {
+  Root: {
+    base: "card",
+    variant: {
+      default: "card--default",
+      flat: "card--flat",
+      bordered: "card--bordered",
+      shadow: "card--shadow",
+    },
+    flag: {
+      isHoverable: "card--hoverable",
+      isPressable: "card--pressable",
+    },
+  },
+  Header: {
+    base: "card__header",
+  },
+  Body: {
+    base: "card__body",
+  },
+  Footer: {
+    base: "card__footer",
+  },
+} as const;

--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -3,6 +3,7 @@ import { splitProps, type Component, type JSX, type ParentComponent } from "soli
 import { twMerge } from "tailwind-merge";
 
 import type { IComponentBaseProps } from "../types";
+import { CLASSES } from "./Card.classes";
 
 export type CardVariant = "default" | "flat" | "bordered" | "shadow";
 
@@ -20,13 +21,6 @@ export type CardRootProps = CardContextlessProps<HTMLDivElement> & {
 export type CardHeaderProps = CardContextlessProps<HTMLDivElement>;
 export type CardBodyProps = CardContextlessProps<HTMLDivElement>;
 export type CardFooterProps = CardContextlessProps<HTMLDivElement>;
-
-const CARD_VARIANT_CLASS: Record<CardVariant, string> = {
-  default: "card--default",
-  flat: "card--flat",
-  bordered: "card--bordered",
-  shadow: "card--shadow",
-};
 
 const invokeEventHandler = (handler: unknown, event: Event) => {
   if (typeof handler === "function") {
@@ -72,10 +66,10 @@ const CardRoot: ParentComponent<CardRootProps> = (props) => {
     <div
       {...others}
       class={twMerge(
-        "card",
-        CARD_VARIANT_CLASS[variant()],
-        local.isHoverable && "card--hoverable",
-        local.isPressable && "card--pressable",
+        CLASSES.Root.base,
+        CLASSES.Root.variant[variant()],
+        local.isHoverable && CLASSES.Root.flag.isHoverable,
+        local.isPressable && CLASSES.Root.flag.isPressable,
         local.class,
         local.className,
       )}
@@ -106,7 +100,7 @@ const CardHeader: Component<CardHeaderProps> = (props) => {
   return (
     <div
       {...others}
-      class={twMerge("card__header", local.class, local.className)}
+      class={twMerge(CLASSES.Header.base, local.class, local.className)}
       data-slot="card-header"
       data-theme={local.dataTheme}
       style={local.style}
@@ -128,7 +122,7 @@ const CardBody: Component<CardBodyProps> = (props) => {
   return (
     <div
       {...others}
-      class={twMerge("card__body", local.class, local.className)}
+      class={twMerge(CLASSES.Body.base, local.class, local.className)}
       data-slot="card-body"
       data-theme={local.dataTheme}
       style={local.style}
@@ -150,7 +144,7 @@ const CardFooter: Component<CardFooterProps> = (props) => {
   return (
     <div
       {...others}
-      class={twMerge("card__footer", local.class, local.className)}
+      class={twMerge(CLASSES.Footer.base, local.class, local.className)}
       data-slot="card-footer"
       data-theme={local.dataTheme}
       style={local.style}

--- a/src/components/checkbox-group/CheckboxGroup.classes.ts
+++ b/src/components/checkbox-group/CheckboxGroup.classes.ts
@@ -1,0 +1,11 @@
+export const CLASSES = {
+  base: "checkbox-group",
+  variant: {
+    primary: "checkbox-group--primary",
+    secondary: "checkbox-group--secondary",
+  },
+  flag: {
+    disabled: "checkbox-group--disabled",
+    invalid: "checkbox-group--invalid",
+  },
+} as const;

--- a/src/components/checkbox-group/CheckboxGroup.tsx
+++ b/src/components/checkbox-group/CheckboxGroup.tsx
@@ -4,14 +4,10 @@ import { twMerge } from "tailwind-merge";
 
 import type { CheckboxVariant } from "../checkbox";
 import type { IComponentBaseProps } from "../types";
+import { CLASSES } from "./CheckboxGroup.classes";
 import { CheckboxGroupContext, type CheckboxGroupContextValue } from "./context";
 
 export type CheckboxGroupVariant = CheckboxVariant;
-
-const VARIANT_CLASS_MAP: Record<CheckboxGroupVariant, string> = {
-  primary: "checkbox-group--primary",
-  secondary: "checkbox-group--secondary",
-};
 
 export type CheckboxGroupProps = Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "onChange"> &
   IComponentBaseProps & {
@@ -91,10 +87,10 @@ const CheckboxGroup: Component<CheckboxGroupProps> = (props) => {
         data-disabled={isDisabled() ? "true" : "false"}
         data-invalid={isInvalid() ? "true" : "false"}
         class={twMerge(
-          "checkbox-group",
-          VARIANT_CLASS_MAP[variant()],
-          isDisabled() && "checkbox-group--disabled",
-          isInvalid() && "checkbox-group--invalid",
+          CLASSES.base,
+          CLASSES.variant[variant()],
+          isDisabled() && CLASSES.flag.disabled,
+          isInvalid() && CLASSES.flag.invalid,
           local.class,
           local.className,
         )}

--- a/src/components/close-button/CloseButton.classes.ts
+++ b/src/components/close-button/CloseButton.classes.ts
@@ -1,0 +1,11 @@
+export const CLASSES = {
+  base: "close-button",
+  variant: {
+    default: "close-button--default",
+  },
+  slot: {
+    icon: "close-button__icon",
+    iconStart: "close-button__icon--start",
+    iconEnd: "close-button__icon--end",
+  },
+} as const;

--- a/src/components/close-button/CloseButton.tsx
+++ b/src/components/close-button/CloseButton.tsx
@@ -3,12 +3,9 @@ import { splitProps, type Component, type JSX } from "solid-js";
 import { twMerge } from "tailwind-merge";
 
 import type { IComponentBaseProps } from "../types";
+import { CLASSES } from "./CloseButton.classes";
 
 export type CloseButtonVariant = "default";
-
-const VARIANT_CLASS_MAP: Record<CloseButtonVariant, string> = {
-  default: "close-button--default",
-};
 
 export type CloseButtonProps = Omit<JSX.ButtonHTMLAttributes<HTMLButtonElement>, "disabled"> &
   IComponentBaseProps & {
@@ -45,8 +42,8 @@ const CloseButton: Component<CloseButtonProps> = (props) => {
       type={local.type ?? "button"}
       aria-label={local["aria-label"] ?? "Close"}
       class={twMerge(
-        "close-button",
-        VARIANT_CLASS_MAP[variant()],
+        CLASSES.base,
+        CLASSES.variant[variant()],
         local.class,
         local.className,
       )}
@@ -58,13 +55,19 @@ const CloseButton: Component<CloseButtonProps> = (props) => {
       aria-disabled={disabled() ? "true" : "false"}
     >
       {local.startIcon ? (
-        <span class="close-button__icon close-button__icon--start" data-slot="close-button-start-icon">
+        <span
+          class={twMerge(CLASSES.slot.icon, CLASSES.slot.iconStart)}
+          data-slot="close-button-start-icon"
+        >
           {local.startIcon}
         </span>
       ) : null}
       {local.children}
       {local.endIcon ? (
-        <span class="close-button__icon close-button__icon--end" data-slot="close-button-end-icon">
+        <span
+          class={twMerge(CLASSES.slot.icon, CLASSES.slot.iconEnd)}
+          data-slot="close-button-end-icon"
+        >
           {local.endIcon}
         </span>
       ) : null}

--- a/src/components/combo-box/ComboBox.classes.ts
+++ b/src/components/combo-box/ComboBox.classes.ts
@@ -1,0 +1,42 @@
+export const CLASSES = {
+  Root: {
+    base: "combo-box",
+    variant: {
+      primary: "combo-box--primary",
+      secondary: "combo-box--secondary",
+    },
+    flag: {
+      fullWidth: "combo-box--full-width",
+    },
+  },
+  InputGroup: {
+    base: "combo-box__input-group",
+    flag: {
+      fullWidth: "combo-box__input-group--full-width",
+    },
+  },
+  Input: {
+    base: "combo-box__input",
+  },
+  Trigger: {
+    base: "combo-box__trigger",
+    icon: "combo-box__trigger-icon",
+  },
+  Popover: {
+    base: "combo-box__popover",
+  },
+  List: {
+    base: "combo-box__list",
+    empty: "combo-box__empty",
+  },
+  Option: {
+    base: "combo-box__option",
+    label: "combo-box__option-label",
+    indicator: "combo-box__option-indicator",
+  },
+  Icon: {
+    base: "combo-box__icon",
+    start: "combo-box__icon--start",
+    end: "combo-box__icon--end",
+  },
+} as const;

--- a/src/components/combo-box/ComboBox.tsx
+++ b/src/components/combo-box/ComboBox.tsx
@@ -19,6 +19,7 @@ import {
 import { twMerge } from "tailwind-merge";
 
 import type { IComponentBaseProps } from "../types";
+import { CLASSES } from "./ComboBox.classes";
 
 export type ComboBoxVariant = "primary" | "secondary";
 export type ComboBoxMenuTrigger = "focus" | "input" | "manual";
@@ -68,11 +69,6 @@ type ComboBoxContextValue = {
 };
 
 const ComboBoxContext = createContext<ComboBoxContextValue>();
-
-const VARIANT_CLASS_MAP: Record<ComboBoxVariant, string> = {
-  primary: "combo-box--primary",
-  secondary: "combo-box--secondary",
-};
 
 const invokeEventHandler = <T extends Event>(handler: unknown, event: T) => {
   if (typeof handler === "function") {
@@ -511,9 +507,9 @@ const ComboBoxRoot: ParentComponent<ComboBoxRootProps> = (props) => {
           }
         }}
         class={twMerge(
-          "combo-box",
-          VARIANT_CLASS_MAP[variant()],
-          fullWidth() && "combo-box--full-width",
+          CLASSES.Root.base,
+          CLASSES.Root.variant[variant()],
+          fullWidth() && CLASSES.Root.flag.fullWidth,
           local.class,
           local.className,
         )}
@@ -535,7 +531,10 @@ const ComboBoxRoot: ParentComponent<ComboBoxRootProps> = (props) => {
           <>
             <ComboBoxInputGroup>
               <Show when={local.startIcon}>
-                <span class="combo-box__icon combo-box__icon--start" data-slot="combobox-start-icon">
+                <span
+                  class={twMerge(CLASSES.Icon.base, CLASSES.Icon.start)}
+                  data-slot="combobox-start-icon"
+                >
                   {local.startIcon}
                 </span>
               </Show>
@@ -560,8 +559,8 @@ const ComboBoxInputGroup: ParentComponent<ComboBoxInputGroupProps> = (props) => 
     <div
       {...others}
       class={twMerge(
-        "combo-box__input-group",
-        context?.fullWidth() && "combo-box__input-group--full-width",
+        CLASSES.InputGroup.base,
+        context?.fullWidth() && CLASSES.InputGroup.flag.fullWidth,
         local.class,
         local.className,
       )}
@@ -700,7 +699,7 @@ const ComboBoxInput: Component<ComboBoxInputProps> = (props) => {
       aria-activedescendant={activeOptionId()}
       aria-disabled={context?.isDisabled() ? "true" : undefined}
       aria-invalid={context?.isInvalid() ? "true" : undefined}
-      class={twMerge("combo-box__input", local.class, local.className)}
+      class={twMerge(CLASSES.Input.base, local.class, local.className)}
       data-slot="combobox-input"
       data-theme={local.dataTheme}
       style={local.style}
@@ -738,7 +737,7 @@ const ComboBoxTrigger: Component<ComboBoxTriggerProps> = (props) => {
     <button
       {...others}
       type="button"
-      class={twMerge("combo-box__trigger", local.class, local.className)}
+      class={twMerge(CLASSES.Trigger.base, local.class, local.className)}
       data-slot="combobox-trigger"
       data-open={context?.isOpen() ? "true" : "false"}
       data-theme={local.dataTheme}
@@ -752,14 +751,17 @@ const ComboBoxTrigger: Component<ComboBoxTriggerProps> = (props) => {
       onClick={handleClick}
     >
       {local.startIcon ? (
-        <span class="combo-box__icon combo-box__icon--start" data-slot="combobox-trigger-start-icon">
+        <span
+          class={twMerge(CLASSES.Icon.base, CLASSES.Icon.start)}
+          data-slot="combobox-trigger-start-icon"
+        >
           {local.startIcon}
         </span>
       ) : null}
       {local.children}
       {local.endIcon ? (
         <span
-          class="combo-box__icon combo-box__icon--end combo-box__trigger-icon"
+          class={twMerge(CLASSES.Icon.base, CLASSES.Icon.end, CLASSES.Trigger.icon)}
           data-slot="combobox-trigger-end-icon"
         >
           {local.endIcon}
@@ -776,7 +778,7 @@ const ComboBoxPopover: ParentComponent<ComboBoxPopoverProps> = (props) => {
   return (
     <div
       {...others}
-      class={twMerge("combo-box__popover", local.class, local.className)}
+      class={twMerge(CLASSES.Popover.base, local.class, local.className)}
       data-slot="combobox-popover"
       data-open={context?.isOpen() ? "true" : "false"}
       data-theme={local.dataTheme}
@@ -806,7 +808,7 @@ const ComboBoxList: Component<ComboBoxListProps> = (props) => {
       {...others}
       id={context?.listBoxId}
       role="listbox"
-      class={twMerge("combo-box__list", local.class, local.className)}
+      class={twMerge(CLASSES.List.base, local.class, local.className)}
       data-slot="combobox-list"
       data-theme={local.dataTheme}
       style={local.style}
@@ -815,7 +817,7 @@ const ComboBoxList: Component<ComboBoxListProps> = (props) => {
         when={items().length > 0}
         fallback={
           local.renderEmptyState?.() ?? (
-            <div class="combo-box__empty" data-slot="combobox-empty-state">
+            <div class={CLASSES.List.empty} data-slot="combobox-empty-state">
               No matching options
             </div>
           )
@@ -846,7 +848,7 @@ const ComboBoxList: Component<ComboBoxListProps> = (props) => {
                 data-selected={selected() ? "true" : "false"}
                 data-active={active() ? "true" : "false"}
                 data-disabled={item.disabled ? "true" : "false"}
-                class="combo-box__option"
+                class={CLASSES.Option.base}
                 onMouseDown={(event) => event.preventDefault()}
                 onMouseEnter={() => {
                   if (item.disabled) return;
@@ -857,12 +859,15 @@ const ComboBoxList: Component<ComboBoxListProps> = (props) => {
                   context?.selectKey(item.key);
                 }}
               >
-                <span class="combo-box__option-label">
+                <span class={CLASSES.Option.label}>
                   {typeof local.children === "function" ? local.children(state) : item.textValue}
                 </span>
                 {local.endIcon ? (
-                  <span class="combo-box__option-indicator" aria-hidden="true">
-                    <span class="combo-box__icon combo-box__icon--end" data-slot="combobox-option-end-icon">
+                  <span class={CLASSES.Option.indicator} aria-hidden="true">
+                    <span
+                      class={twMerge(CLASSES.Icon.base, CLASSES.Icon.end)}
+                      data-slot="combobox-option-end-icon"
+                    >
                       {local.endIcon}
                     </span>
                   </span>

--- a/src/components/date-field/DateField.classes.ts
+++ b/src/components/date-field/DateField.classes.ts
@@ -1,0 +1,37 @@
+export const CLASSES = {
+  Root: {
+    base: "date-field",
+    variant: {
+      primary: "date-field--primary",
+      secondary: "date-field--secondary",
+    },
+    flag: {
+      fullWidth: "date-field--full-width",
+    },
+  },
+  Group: {
+    base: "date-input-group",
+    variant: {
+      primary: "date-input-group--primary",
+      secondary: "date-input-group--secondary",
+    },
+    flag: {
+      fullWidth: "date-input-group--full-width",
+    },
+  },
+  Input: {
+    base: "date-input-group__input",
+  },
+  InputContainer: {
+    base: "date-input-group__input-container",
+  },
+  Segment: {
+    base: "date-input-group__segment",
+  },
+  Prefix: {
+    base: "date-input-group__prefix",
+  },
+  Suffix: {
+    base: "date-input-group__suffix",
+  },
+} as const;

--- a/src/components/date-field/DateField.tsx
+++ b/src/components/date-field/DateField.tsx
@@ -12,18 +12,9 @@ import {
 import { twMerge } from "tailwind-merge";
 
 import type { IComponentBaseProps } from "../types";
+import { CLASSES } from "./DateField.classes";
 
 export type DateFieldVariant = "primary" | "secondary";
-
-const VARIANT_CLASS_MAP: Record<DateFieldVariant, string> = {
-  primary: "date-field--primary",
-  secondary: "date-field--secondary",
-};
-
-const GROUP_VARIANT_CLASS_MAP: Record<DateFieldVariant, string> = {
-  primary: "date-input-group--primary",
-  secondary: "date-input-group--secondary",
-};
 
 type DateFieldContextValue = {
   value: Accessor<string>;
@@ -168,9 +159,9 @@ const DateFieldRoot: ParentComponent<DateFieldRootProps> = (props) => {
       <div
         {...others}
         class={twMerge(
-          "date-field",
-          VARIANT_CLASS_MAP[variant()],
-          fullWidth() && "date-field--full-width",
+          CLASSES.Root.base,
+          CLASSES.Root.variant[variant()],
+          fullWidth() && CLASSES.Root.flag.fullWidth,
           local.class,
           local.className,
         )}
@@ -212,9 +203,9 @@ const DateFieldGroup: ParentComponent<DateFieldGroupProps> = (props) => {
     <div
       {...others}
       class={twMerge(
-        "date-input-group",
-        GROUP_VARIANT_CLASS_MAP[context?.variant() ?? "primary"],
-        context?.fullWidth() && "date-input-group--full-width",
+        CLASSES.Group.base,
+        CLASSES.Group.variant[context?.variant() ?? "primary"],
+        context?.fullWidth() && CLASSES.Group.flag.fullWidth,
         local.class,
         local.className,
       )}
@@ -256,7 +247,7 @@ const DateFieldInput: Component<DateFieldInputProps> = (props) => {
     <input
       {...others}
       type="date"
-      class={twMerge("date-input-group__input", local.class, local.className)}
+      class={twMerge(CLASSES.Input.base, local.class, local.className)}
       data-slot="date-input-group-input"
       data-theme={local.dataTheme}
       style={local.style}
@@ -278,7 +269,7 @@ const DateFieldInputContainer: ParentComponent<DateFieldInputContainerProps> = (
   return (
     <div
       {...others}
-      class={twMerge("date-input-group__input-container", local.class, local.className)}
+      class={twMerge(CLASSES.InputContainer.base, local.class, local.className)}
       data-slot="date-input-group-input-container"
       data-theme={local.dataTheme}
       style={local.style}
@@ -301,7 +292,7 @@ const DateFieldSegment: ParentComponent<DateFieldSegmentProps> = (props) => {
   return (
     <span
       {...others}
-      class={twMerge("date-input-group__segment", local.class, local.className)}
+      class={twMerge(CLASSES.Segment.base, local.class, local.className)}
       data-slot="date-input-group-segment"
       data-type={local.segment?.type}
       data-placeholder={local.segment?.isPlaceholder ? "true" : undefined}
@@ -322,7 +313,7 @@ const DateFieldPrefix: ParentComponent<DateFieldPrefixProps> = (props) => {
   return (
     <div
       {...others}
-      class={twMerge("date-input-group__prefix", local.class, local.className)}
+      class={twMerge(CLASSES.Prefix.base, local.class, local.className)}
       data-slot="date-input-group-prefix"
       data-theme={local.dataTheme}
       style={local.style}
@@ -338,7 +329,7 @@ const DateFieldSuffix: ParentComponent<DateFieldSuffixProps> = (props) => {
   return (
     <div
       {...others}
-      class={twMerge("date-input-group__suffix", local.class, local.className)}
+      class={twMerge(CLASSES.Suffix.base, local.class, local.className)}
       data-slot="date-input-group-suffix"
       data-theme={local.dataTheme}
       style={local.style}

--- a/src/components/description/Description.classes.ts
+++ b/src/components/description/Description.classes.ts
@@ -1,0 +1,3 @@
+export const CLASSES = {
+  base: "description",
+} as const;

--- a/src/components/description/Description.tsx
+++ b/src/components/description/Description.tsx
@@ -3,6 +3,7 @@ import { splitProps, type Component, type JSX } from "solid-js";
 import { twMerge } from "tailwind-merge";
 
 import type { IComponentBaseProps } from "../types";
+import { CLASSES } from "./Description.classes";
 
 export type DescriptionRootProps = JSX.HTMLAttributes<HTMLSpanElement> & IComponentBaseProps;
 
@@ -19,7 +20,7 @@ const DescriptionRoot: Component<DescriptionRootProps> = (props) => {
   return (
     <span
       {...others}
-      class={twMerge("description", local.class, local.className)}
+      class={twMerge(CLASSES.base, local.class, local.className)}
       data-slot="description"
       slot={local.slot ?? "description"}
       data-theme={local.dataTheme}

--- a/src/components/error-message/ErrorMessage.classes.ts
+++ b/src/components/error-message/ErrorMessage.classes.ts
@@ -1,0 +1,3 @@
+export const CLASSES = {
+  base: "error-message",
+} as const;

--- a/src/components/error-message/ErrorMessage.tsx
+++ b/src/components/error-message/ErrorMessage.tsx
@@ -3,6 +3,7 @@ import { splitProps, type Component, type JSX } from "solid-js";
 import { twMerge } from "tailwind-merge";
 
 import type { IComponentBaseProps } from "../types";
+import { CLASSES } from "./ErrorMessage.classes";
 
 export type ErrorMessageRootProps = JSX.HTMLAttributes<HTMLSpanElement> & IComponentBaseProps;
 
@@ -19,7 +20,7 @@ const ErrorMessageRoot: Component<ErrorMessageRootProps> = (props) => {
   return (
     <span
       {...others}
-      class={twMerge("error-message", local.class, local.className)}
+      class={twMerge(CLASSES.base, local.class, local.className)}
       data-slot="error-message"
       slot={local.slot ?? "errorMessage"}
       data-theme={local.dataTheme}

--- a/src/components/field-error/FieldError.classes.ts
+++ b/src/components/field-error/FieldError.classes.ts
@@ -1,0 +1,3 @@
+export const CLASSES = {
+  base: "field-error",
+} as const;

--- a/src/components/field-error/FieldError.tsx
+++ b/src/components/field-error/FieldError.tsx
@@ -5,6 +5,7 @@ import { twMerge } from "tailwind-merge";
 import type { FormController } from "../../hooks/form";
 import { useFieldError } from "../../hooks/form";
 import type { IComponentBaseProps } from "../types";
+import { CLASSES } from "./FieldError.classes";
 
 export type FieldErrorRenderProps = {
   isVisible: boolean;
@@ -74,7 +75,7 @@ const FieldErrorRoot: Component<FieldErrorRootProps> = (props) => {
     <div
       ref={rootRef}
       {...others}
-      class={twMerge("field-error", local.class, local.className)}
+      class={twMerge(CLASSES.base, local.class, local.className)}
       data-slot="field-error"
       data-visible={isVisible() ? "true" : "false"}
       slot={local.slot ?? "errorMessage"}

--- a/src/components/fieldset/Fieldset.classes.ts
+++ b/src/components/fieldset/Fieldset.classes.ts
@@ -1,0 +1,14 @@
+export const CLASSES = {
+  Root: {
+    base: "fieldset",
+  },
+  Legend: {
+    base: "fieldset__legend",
+  },
+  Group: {
+    base: "fieldset__group",
+  },
+  Actions: {
+    base: "fieldset__actions",
+  },
+} as const;

--- a/src/components/fieldset/Fieldset.tsx
+++ b/src/components/fieldset/Fieldset.tsx
@@ -3,6 +3,7 @@ import { splitProps, type Component, type JSX, type ParentComponent } from "soli
 import { twMerge } from "tailwind-merge";
 
 import type { IComponentBaseProps } from "../types";
+import { CLASSES } from "./Fieldset.classes";
 
 export type FieldsetRootProps = JSX.FieldsetHTMLAttributes<HTMLFieldSetElement> & IComponentBaseProps;
 
@@ -30,7 +31,7 @@ const FieldsetRoot: ParentComponent<FieldsetRootProps> = (props) => {
   return (
     <fieldset
       {...others}
-      class={twMerge("fieldset", local.class, local.className)}
+      class={twMerge(CLASSES.Root.base, local.class, local.className)}
       data-slot="fieldset"
       data-theme={local.dataTheme}
       style={local.style}
@@ -52,7 +53,7 @@ const FieldsetLegend: ParentComponent<FieldsetLegendProps> = (props) => {
   return (
     <legend
       {...others}
-      class={twMerge("fieldset__legend", local.class, local.className)}
+      class={twMerge(CLASSES.Legend.base, local.class, local.className)}
       data-slot="fieldset-legend"
       data-theme={local.dataTheme}
       style={local.style}
@@ -74,7 +75,7 @@ const FieldGroup: ParentComponent<FieldGroupProps> = (props) => {
   return (
     <div
       {...others}
-      class={twMerge("fieldset__group", local.class, local.className)}
+      class={twMerge(CLASSES.Group.base, local.class, local.className)}
       data-slot="fieldset-field-group"
       data-theme={local.dataTheme}
       style={local.style}
@@ -96,7 +97,7 @@ const FieldsetActions: ParentComponent<FieldsetActionsProps> = (props) => {
   return (
     <div
       {...others}
-      class={twMerge("fieldset__actions", local.class, local.className)}
+      class={twMerge(CLASSES.Actions.base, local.class, local.className)}
       data-slot="fieldset-actions"
       data-theme={local.dataTheme}
       style={local.style}

--- a/src/components/form/Form.classes.ts
+++ b/src/components/form/Form.classes.ts
@@ -1,0 +1,3 @@
+export const CLASSES = {
+  base: "form",
+} as const;

--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -3,6 +3,7 @@ import { splitProps, type Component, type JSX } from "solid-js";
 import { twMerge } from "tailwind-merge";
 
 import type { IComponentBaseProps } from "../types";
+import { CLASSES } from "./Form.classes";
 
 export type FormRootProps = JSX.FormHTMLAttributes<HTMLFormElement> & IComponentBaseProps;
 
@@ -17,7 +18,7 @@ const FormRoot: Component<FormRootProps> = (props) => {
   return (
     <form
       {...others}
-      class={twMerge("form", local.class, local.className)}
+      class={twMerge(CLASSES.base, local.class, local.className)}
       data-slot="form"
       data-theme={local.dataTheme}
       style={local.style}

--- a/src/components/header/Header.classes.ts
+++ b/src/components/header/Header.classes.ts
@@ -1,0 +1,3 @@
+export const CLASSES = {
+  base: "header",
+} as const;

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -3,6 +3,7 @@ import { splitProps, type Component, type JSX } from "solid-js";
 import { twMerge } from "tailwind-merge";
 
 import type { IComponentBaseProps } from "../types";
+import { CLASSES } from "./Header.classes";
 
 export type HeaderRootProps = JSX.HTMLAttributes<HTMLDivElement> & IComponentBaseProps;
 
@@ -18,7 +19,7 @@ const HeaderRoot: Component<HeaderRootProps> = (props) => {
   return (
     <div
       {...others}
-      class={twMerge("header", local.class, local.className)}
+      class={twMerge(CLASSES.base, local.class, local.className)}
       data-slot="header"
       data-theme={local.dataTheme}
       style={local.style}

--- a/src/components/input-group/InputGroup.classes.ts
+++ b/src/components/input-group/InputGroup.classes.ts
@@ -1,0 +1,21 @@
+export const CLASSES = {
+  Root: {
+    base: "input-group",
+    variant: {
+      primary: "input-group--primary",
+      secondary: "input-group--secondary",
+    },
+    flag: {
+      fullWidth: "input-group--full-width",
+    },
+  },
+  Input: {
+    base: "input-group__input",
+  },
+  Prefix: {
+    base: "input-group__prefix",
+  },
+  Suffix: {
+    base: "input-group__suffix",
+  },
+} as const;

--- a/src/components/input-group/InputGroup.tsx
+++ b/src/components/input-group/InputGroup.tsx
@@ -4,13 +4,9 @@ import { twMerge } from "tailwind-merge";
 
 import { useTextFieldContext, type TextFieldVariant } from "../text-field";
 import type { IComponentBaseProps } from "../types";
+import { CLASSES } from "./InputGroup.classes";
 
 export type InputGroupVariant = TextFieldVariant;
-
-const VARIANT_CLASS_MAP: Record<InputGroupVariant, string> = {
-  primary: "input-group--primary",
-  secondary: "input-group--secondary",
-};
 
 type InputGroupContextValue = {
   variant: Accessor<InputGroupVariant>;
@@ -123,9 +119,9 @@ const InputGroupRoot: ParentComponent<InputGroupRootProps> = (props) => {
           }
         }}
         class={twMerge(
-          "input-group",
-          VARIANT_CLASS_MAP[variant()],
-          fullWidth() && "input-group--full-width",
+          CLASSES.Root.base,
+          CLASSES.Root.variant[variant()],
+          fullWidth() && CLASSES.Root.flag.fullWidth,
           local.class,
           local.className,
         )}
@@ -163,7 +159,7 @@ const InputGroupInput: Component<InputGroupInputProps> = (props) => {
   return (
     <input
       {...others}
-      class={twMerge("input-group__input", local.class, local.className)}
+      class={twMerge(CLASSES.Input.base, local.class, local.className)}
       data-slot="input-group-input"
       data-theme={local.dataTheme}
       style={local.style}
@@ -193,7 +189,7 @@ const InputGroupTextArea: Component<InputGroupTextAreaProps> = (props) => {
   return (
     <textarea
       {...others}
-      class={twMerge("input-group__input", local.class, local.className)}
+      class={twMerge(CLASSES.Input.base, local.class, local.className)}
       data-slot="input-group-textarea"
       data-theme={local.dataTheme}
       style={local.style}
@@ -210,7 +206,7 @@ const InputGroupPrefix: ParentComponent<InputGroupPrefixProps> = (props) => {
   return (
     <div
       {...others}
-      class={twMerge("input-group__prefix", local.class, local.className)}
+      class={twMerge(CLASSES.Prefix.base, local.class, local.className)}
       data-slot="input-group-prefix"
       data-theme={local.dataTheme}
       style={local.style}
@@ -226,7 +222,7 @@ const InputGroupSuffix: ParentComponent<InputGroupSuffixProps> = (props) => {
   return (
     <div
       {...others}
-      class={twMerge("input-group__suffix", local.class, local.className)}
+      class={twMerge(CLASSES.Suffix.base, local.class, local.className)}
       data-slot="input-group-suffix"
       data-theme={local.dataTheme}
       style={local.style}

--- a/src/components/input-otp/InputOTP.classes.ts
+++ b/src/components/input-otp/InputOTP.classes.ts
@@ -1,0 +1,23 @@
+export const CLASSES = {
+  Root: {
+    base: "input-otp",
+    variant: {
+      primary: "input-otp--primary",
+      secondary: "input-otp--secondary",
+    },
+  },
+  Input: {
+    base: "input-otp__input",
+  },
+  Group: {
+    base: "input-otp__group",
+  },
+  Slot: {
+    base: "input-otp__slot",
+    value: "input-otp__slot-value",
+    caret: "input-otp__caret",
+  },
+  Separator: {
+    base: "input-otp__separator",
+  },
+} as const;

--- a/src/components/input-otp/InputOTP.tsx
+++ b/src/components/input-otp/InputOTP.tsx
@@ -17,13 +17,9 @@ import {
 import { twMerge } from "tailwind-merge";
 
 import type { IComponentBaseProps } from "../types";
+import { CLASSES } from "./InputOTP.classes";
 
 export type InputOTPVariant = "primary" | "secondary";
-
-const VARIANT_CLASS_MAP: Record<InputOTPVariant, string> = {
-  primary: "input-otp--primary",
-  secondary: "input-otp--secondary",
-};
 
 export const REGEXP_ONLY_DIGITS = "^\\d+$";
 export const REGEXP_ONLY_CHARS = "^[a-zA-Z]+$";
@@ -334,8 +330,8 @@ const InputOTPRoot: ParentComponent<InputOTPRootProps> = (props) => {
           }
         }}
         class={twMerge(
-          "input-otp",
-          VARIANT_CLASS_MAP[variant()],
+          CLASSES.Root.base,
+          CLASSES.Root.variant[variant()],
           local.class,
           local.className,
         )}
@@ -349,7 +345,7 @@ const InputOTPRoot: ParentComponent<InputOTPRootProps> = (props) => {
       >
         <input
           ref={inputRef}
-          class={twMerge("input-otp__input", local.inputClassName)}
+          class={twMerge(CLASSES.Input.base, local.inputClassName)}
           data-slot="input-otp-input"
           type="text"
           inputMode={local.inputMode}
@@ -388,7 +384,7 @@ const InputOTPGroup: ParentComponent<InputOTPGroupProps> = (props) => {
   return (
     <div
       {...others}
-      class={twMerge("input-otp__group", local.class, local.className)}
+      class={twMerge(CLASSES.Group.base, local.class, local.className)}
       data-slot="input-otp-group"
       data-theme={local.dataTheme}
       style={local.style}
@@ -428,7 +424,7 @@ const InputOTPSlot: Component<InputOTPSlotProps> = (props) => {
   return (
     <div
       {...others}
-      class={twMerge("input-otp__slot", local.class, local.className)}
+      class={twMerge(CLASSES.Slot.base, local.class, local.className)}
       data-slot="input-otp-slot"
       data-active={isActive() ? "true" : undefined}
       data-filled={char().length > 0 ? "true" : undefined}
@@ -439,12 +435,12 @@ const InputOTPSlot: Component<InputOTPSlotProps> = (props) => {
       onMouseDown={handleMouseDown}
     >
       <Show when={char().length > 0}>
-        <div class="input-otp__slot-value" data-slot="input-otp-slot-value">
+        <div class={CLASSES.Slot.value} data-slot="input-otp-slot-value">
           {char()}
         </div>
       </Show>
       <Show when={isActive() && char().length === 0}>
-        <div class="input-otp__caret" data-slot="input-otp-caret" />
+        <div class={CLASSES.Slot.caret} data-slot="input-otp-caret" />
       </Show>
     </div>
   );
@@ -456,7 +452,7 @@ const InputOTPSeparator: ParentComponent<InputOTPSeparatorProps> = (props) => {
   return (
     <div
       {...others}
-      class={twMerge("input-otp__separator", local.class, local.className)}
+      class={twMerge(CLASSES.Separator.base, local.class, local.className)}
       data-slot="input-otp-separator"
       data-theme={local.dataTheme}
       style={local.style}

--- a/src/components/label/Label.classes.ts
+++ b/src/components/label/Label.classes.ts
@@ -1,0 +1,8 @@
+export const CLASSES = {
+  base: "label",
+  flag: {
+    required: "label--required",
+    disabled: "label--disabled",
+    invalid: "label--invalid",
+  },
+} as const;

--- a/src/components/label/Label.tsx
+++ b/src/components/label/Label.tsx
@@ -3,14 +3,7 @@ import { splitProps, type Component, type JSX } from "solid-js";
 import { twMerge } from "tailwind-merge";
 
 import type { IComponentBaseProps } from "../types";
-
-type LabelState = "required" | "disabled" | "invalid";
-
-const LABEL_STATE_CLASS_MAP: Record<LabelState, string> = {
-  required: "label--required",
-  disabled: "label--disabled",
-  invalid: "label--invalid",
-};
+import { CLASSES } from "./Label.classes";
 
 export type LabelRootProps = Omit<JSX.LabelHTMLAttributes<HTMLLabelElement>, "for"> &
   IComponentBaseProps & {
@@ -40,10 +33,10 @@ const LabelRoot: Component<LabelRootProps> = (props) => {
       {...others}
       for={local.for ?? local.htmlFor}
       class={twMerge(
-        "label",
-        local.isRequired && LABEL_STATE_CLASS_MAP.required,
-        local.isDisabled && LABEL_STATE_CLASS_MAP.disabled,
-        local.isInvalid && LABEL_STATE_CLASS_MAP.invalid,
+        CLASSES.base,
+        local.isRequired && CLASSES.flag.required,
+        local.isDisabled && CLASSES.flag.disabled,
+        local.isInvalid && CLASSES.flag.invalid,
         local.class,
         local.className,
       )}

--- a/src/components/list-box/ListBox.classes.ts
+++ b/src/components/list-box/ListBox.classes.ts
@@ -1,0 +1,23 @@
+export const CLASSES = {
+  Root: {
+    base: "list-box",
+    variant: {
+      default: "list-box--default",
+      danger: "list-box--danger",
+    },
+  },
+  Item: {
+    base: "list-box-item",
+    variant: {
+      default: "list-box-item--default",
+      danger: "list-box-item--danger",
+    },
+  },
+  ItemIndicator: {
+    base: "list-box-item__indicator",
+  },
+  Section: {
+    base: "list-box-section",
+    title: "list-box-section__title",
+  },
+} as const;

--- a/src/components/list-box/ListBox.tsx
+++ b/src/components/list-box/ListBox.tsx
@@ -10,6 +10,7 @@ import {
 import { twMerge } from "tailwind-merge";
 
 import type { IComponentBaseProps } from "../types";
+import { CLASSES } from "./ListBox.classes";
 import {
   ListBoxContext,
   type ListBoxFocusTarget,
@@ -17,11 +18,6 @@ import {
   type ListBoxSelectionMode,
   type ListBoxVariant,
 } from "./context";
-
-const LIST_BOX_VARIANT_CLASS_MAP: Record<ListBoxVariant, string> = {
-  default: "list-box--default",
-  danger: "list-box--danger",
-};
 
 const normalizeKeys = (keys?: Iterable<string | number>): Set<string> => {
   if (!keys) return new Set();
@@ -311,8 +307,8 @@ const ListBoxRoot: Component<ListBoxRootProps> = (props) => {
         data-selection-mode={selectionMode()}
         data-disabled={isDisabled() ? "true" : "false"}
         class={twMerge(
-          "list-box",
-          LIST_BOX_VARIANT_CLASS_MAP[variant()],
+          CLASSES.Root.base,
+          CLASSES.Root.variant[variant()],
           local.class,
           local.className,
         )}

--- a/src/components/list-box/ListBoxItem.tsx
+++ b/src/components/list-box/ListBoxItem.tsx
@@ -14,16 +14,12 @@ import { twMerge } from "tailwind-merge";
 
 import type { IComponentBaseProps } from "../types";
 import { ListBoxContext, type ListBoxVariant } from "./context";
+import { CLASSES } from "./ListBox.classes";
 
 type ListBoxItemRenderProps = {
   isSelected: boolean;
   isFocused: boolean;
   isDisabled: boolean;
-};
-
-const LIST_BOX_ITEM_VARIANT_CLASS_MAP: Record<ListBoxVariant, string> = {
-  default: "list-box-item--default",
-  danger: "list-box-item--danger",
 };
 
 const invokeEventHandler = (handler: unknown, event: Event) => {
@@ -221,8 +217,8 @@ const ListBoxItemRoot: ParentComponent<ListBoxItemRootProps> = (props) => {
         data-focus={isFocused() ? "true" : "false"}
         data-key={key()}
         class={twMerge(
-          "list-box-item",
-          LIST_BOX_ITEM_VARIANT_CLASS_MAP[variant()],
+          CLASSES.Item.base,
+          CLASSES.Item.variant[variant()],
           local.class,
           local.className,
         )}
@@ -264,7 +260,7 @@ const ListBoxItemIndicator: Component<ListBoxItemIndicatorProps> = (props) => {
       data-slot="listbox-item-indicator"
       data-theme={local.dataTheme}
       data-visible={renderState().isSelected ? "true" : undefined}
-      class={twMerge("list-box-item__indicator", local.class, local.className)}
+      class={twMerge(CLASSES.ItemIndicator.base, local.class, local.className)}
       style={local.style}
     >
       {typeof local.children === "function" ? (

--- a/src/components/list-box/ListBoxSection.tsx
+++ b/src/components/list-box/ListBoxSection.tsx
@@ -2,6 +2,7 @@ import { Show, splitProps, type Component, type JSX } from "solid-js";
 import { twMerge } from "tailwind-merge";
 
 import type { IComponentBaseProps } from "../types";
+import { CLASSES } from "./ListBox.classes";
 
 export type ListBoxSectionRootProps = Omit<JSX.HTMLAttributes<HTMLDivElement>, "children"> &
   IComponentBaseProps & {
@@ -26,11 +27,11 @@ const ListBoxSectionRoot: Component<ListBoxSectionRootProps> = (props) => {
       role={local.role ?? "group"}
       data-slot="listbox-section"
       data-theme={local.dataTheme}
-      class={twMerge("list-box-section", local.class, local.className)}
+      class={twMerge(CLASSES.Section.base, local.class, local.className)}
       style={local.style}
     >
       <Show when={local.title}>
-        <span class="list-box-section__title" data-slot="heading">
+        <span class={CLASSES.Section.title} data-slot="heading">
           {local.title}
         </span>
       </Show>

--- a/src/components/menu/Menu.classes.ts
+++ b/src/components/menu/Menu.classes.ts
@@ -1,0 +1,20 @@
+export const CLASSES = {
+  Root: {
+    base: "menu",
+  },
+  Item: {
+    base: "menu-item",
+    variant: {
+      default: "menu-item--default",
+      danger: "menu-item--danger",
+    },
+  },
+  ItemIndicator: {
+    base: "menu-item__indicator",
+    submenu: "menu-item__indicator--submenu",
+  },
+  Section: {
+    base: "menu-section",
+    title: "menu-section__title",
+  },
+} as const;

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -10,6 +10,7 @@ import {
 import { twMerge } from "tailwind-merge";
 
 import type { IComponentBaseProps } from "../types";
+import { CLASSES } from "./Menu.classes";
 import {
   MenuContext,
   type MenuFocusTarget,
@@ -301,7 +302,7 @@ const MenuRoot: Component<MenuRootProps> = (props) => {
         data-theme={local.dataTheme}
         data-selection-mode={selectionMode()}
         data-disabled={isDisabled() ? "true" : "false"}
-        class={twMerge("menu", local.class, local.className)}
+        class={twMerge(CLASSES.Root.base, local.class, local.className)}
         style={local.style}
         onKeyDown={handleKeyDown}
       >

--- a/src/components/menu/MenuItem.tsx
+++ b/src/components/menu/MenuItem.tsx
@@ -14,6 +14,7 @@ import { twMerge } from "tailwind-merge";
 
 import type { IComponentBaseProps } from "../types";
 import { MenuContext, type MenuItemVariant, type MenuSelectionMode } from "./context";
+import { CLASSES } from "./Menu.classes";
 
 type MenuItemRenderProps = {
   isSelected: boolean;
@@ -28,11 +29,6 @@ type MenuItemContextValue = {
 };
 
 const MenuItemStateContext = createContext<MenuItemContextValue>();
-
-const MENU_ITEM_VARIANT_CLASS_MAP: Record<MenuItemVariant, string> = {
-  default: "menu-item--default",
-  danger: "menu-item--danger",
-};
 
 const invokeEventHandler = (handler: unknown, event: Event) => {
   if (typeof handler === "function") {
@@ -255,8 +251,8 @@ const MenuItemRoot: ParentComponent<MenuItemRootProps> = (props) => {
         data-selection-mode={selectionMode()}
         data-key={key()}
         class={twMerge(
-          "menu-item",
-          MENU_ITEM_VARIANT_CLASS_MAP[variant()],
+          CLASSES.Item.base,
+          CLASSES.Item.variant[variant()],
           local.class,
           local.className,
         )}
@@ -304,7 +300,7 @@ const MenuItemIndicator: Component<MenuItemIndicatorProps> = (props) => {
       data-theme={local.dataTheme}
       data-type={type()}
       data-visible={renderState().isSelected ? "true" : undefined}
-      class={twMerge("menu-item__indicator", local.class, local.className)}
+      class={twMerge(CLASSES.ItemIndicator.base, local.class, local.className)}
       style={local.style}
     >
       {typeof local.children === "function" ? (
@@ -358,7 +354,7 @@ const MenuItemSubmenuIndicator: Component<MenuItemSubmenuIndicatorProps> = (prop
       aria-hidden="true"
       data-slot="submenu-indicator"
       data-theme={local.dataTheme}
-      class={twMerge("menu-item__indicator menu-item__indicator--submenu", local.class, local.className)}
+      class={twMerge(CLASSES.ItemIndicator.base, CLASSES.ItemIndicator.submenu, local.class, local.className)}
       style={local.style}
     >
       {local.children ?? (

--- a/src/components/menu/MenuSection.tsx
+++ b/src/components/menu/MenuSection.tsx
@@ -2,6 +2,7 @@ import { Show, splitProps, type Component, type JSX } from "solid-js";
 import { twMerge } from "tailwind-merge";
 
 import type { IComponentBaseProps } from "../types";
+import { CLASSES } from "./Menu.classes";
 
 export type MenuSectionRootProps = Omit<JSX.HTMLAttributes<HTMLDivElement>, "children"> &
   IComponentBaseProps & {
@@ -26,11 +27,11 @@ const MenuSectionRoot: Component<MenuSectionRootProps> = (props) => {
       role={local.role ?? "group"}
       data-slot="menu-section"
       data-theme={local.dataTheme}
-      class={twMerge("menu-section", local.class, local.className)}
+      class={twMerge(CLASSES.Section.base, local.class, local.className)}
       style={local.style}
     >
       <Show when={local.title}>
-        <span class="menu-section__title" data-slot="heading">
+        <span class={CLASSES.Section.title} data-slot="heading">
           {local.title}
         </span>
       </Show>

--- a/src/components/navbar/Navbar.classes.ts
+++ b/src/components/navbar/Navbar.classes.ts
@@ -1,0 +1,49 @@
+// CSS class contract for the Navbar family.
+//
+// Compound shape: this single CLASSES const covers Navbar root + the four sub-components
+// (Section, Stack, Row) that live in sibling files. Each sub-component file imports CLASSES
+// and reads its own slot. This is the pattern for any compound component split across files.
+//
+// Slots used by this family:
+//   - `base`     : always rendered (string or string[])
+//   - `variant`  : enum prop value → class (used by Section's `section` prop)
+//   - `flag`     : boolean prop name → class (used by Stack and Row)
+//   - `color`    : enum prop value → class (used by Row's `color` prop, mapped from ComponentColor)
+
+export const CLASSES = {
+  Navbar: {
+    base: "navbar",
+  },
+  Section: {
+    variant: {
+      start: "navbar-start",
+      center: "navbar-center",
+      end: "navbar-end",
+    },
+  },
+  Stack: {
+    base: "navbar-stack",
+    flag: {
+      sticky: "sticky top-0 z-30",
+      container: "max-w-screen-xl mx-auto px-4",
+    },
+  },
+  Row: {
+    base: ["flex", "items-center"],
+    flag: {
+      bordered: "border-b border-gray-200",
+      padded: "px-4 py-2",
+    },
+    color: {
+      ghost: "bg-base-100",
+      neutral: "bg-neutral text-neutral-content",
+      primary: "bg-primary text-primary-content",
+      secondary: "bg-secondary text-secondary-content",
+      accent: "bg-accent text-accent-content",
+      info: "bg-info text-info-content",
+      success: "bg-success text-success-content",
+      warning: "bg-warning text-warning-content",
+      error: "bg-error text-error-content",
+    },
+  },
+} as const;

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -6,6 +6,7 @@ import NavbarSection from "./NavbarSection";
 import NavbarStack from "./NavbarStack";
 import NavbarRow from "./NavbarRow";
 import type { IComponentBaseProps } from "../types";
+import { CLASSES } from "./Navbar.classes";
 
 export type NavbarProps = JSX.HTMLAttributes<HTMLElement> &
   IComponentBaseProps & {
@@ -25,7 +26,7 @@ const Navbar = (props: NavbarProps): JSX.Element => {
   ]);
 
   const Tag = (local.as || "div") as keyof JSX.IntrinsicElements;
-  const classes = () => twMerge("navbar", local.class, local.className);
+  const classes = () => twMerge(CLASSES.Navbar.base, local.class, local.className);
 
   return (
     <Dynamic

--- a/src/components/navbar/NavbarRow.tsx
+++ b/src/components/navbar/NavbarRow.tsx
@@ -5,8 +5,8 @@ import {
   children as resolveChildren,
 } from "solid-js";
 import { twMerge } from "tailwind-merge";
-import { clsx } from "clsx";
 import type { IComponentBaseProps, ComponentColor } from "../types";
+import { CLASSES } from "./Navbar.classes";
 
 export type NavbarRowProps = JSX.HTMLAttributes<HTMLDivElement> &
   IComponentBaseProps & {
@@ -29,22 +29,15 @@ const NavbarRow = (props: NavbarRowProps): JSX.Element => {
 
   const resolvedChildren = resolveChildren(() => local.children);
 
+  const colorKey = (): keyof typeof CLASSES.Row.color =>
+    !local.color || local.color === "ghost" ? "ghost" : local.color;
+
   const classes = createMemo(() =>
     twMerge(
-      "flex items-center",
-      clsx({
-        "border-b border-gray-200": local.bordered === true,
-        "px-4 py-2": local.padded !== false,
-        "bg-base-100": !local.color || local.color === "ghost", // Default to base-100 (usually light bg, dark text)
-        "bg-neutral text-neutral-content": local.color === "neutral",
-        "bg-primary text-primary-content": local.color === "primary",
-        "bg-secondary text-secondary-content": local.color === "secondary",
-        "bg-accent text-accent-content": local.color === "accent",
-        "bg-info text-info-content": local.color === "info",
-        "bg-success text-success-content": local.color === "success",
-        "bg-warning text-warning-content": local.color === "warning",
-        "bg-error text-error-content": local.color === "error",
-      }),
+      ...CLASSES.Row.base,
+      local.bordered === true && CLASSES.Row.flag.bordered,
+      local.padded !== false && CLASSES.Row.flag.padded,
+      CLASSES.Row.color[colorKey()],
       local.class,
       local.className,
     ),

--- a/src/components/navbar/NavbarSection.tsx
+++ b/src/components/navbar/NavbarSection.tsx
@@ -1,6 +1,6 @@
 import { type JSX, splitProps } from "solid-js";
-import { clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
+import { CLASSES } from "./Navbar.classes";
 
 export type NavbarSectionProps = JSX.HTMLAttributes<HTMLDivElement> & {
   section: "start" | "center" | "end";
@@ -20,13 +20,9 @@ const NavbarSection = (props: NavbarSectionProps): JSX.Element => {
 
   const classes = () =>
     twMerge(
+      CLASSES.Section.variant[local.section],
       local.class,
       local.className,
-      clsx({
-        "navbar-start": local.section === "start",
-        "navbar-center": local.section === "center",
-        "navbar-end": local.section === "end",
-      }),
     );
 
   return (

--- a/src/components/navbar/NavbarStack.tsx
+++ b/src/components/navbar/NavbarStack.tsx
@@ -1,14 +1,12 @@
 import {
   type JSX,
-  type ParentProps,
   splitProps,
   createMemo,
   children as resolveChildren,
 } from "solid-js";
 import { twMerge } from "tailwind-merge";
-import { clsx } from "clsx";
 import type { IComponentBaseProps } from "../types";
-import NavbarRow from "./NavbarRow";
+import { CLASSES } from "./Navbar.classes";
 
 export type NavbarStackProps = JSX.HTMLAttributes<HTMLDivElement> &
   IComponentBaseProps & {
@@ -33,13 +31,11 @@ const NavbarStack = (props: NavbarStackProps): JSX.Element => {
 
   const classes = createMemo(() =>
     twMerge(
-      "navbar-stack",
+      CLASSES.Stack.base,
+      local.sticky && CLASSES.Stack.flag.sticky,
+      local.container && CLASSES.Stack.flag.container,
       local.class,
       local.className,
-      clsx({
-        "sticky top-0 z-30": local.sticky,
-        "max-w-screen-xl mx-auto px-4": local.container,
-      }),
     ),
   );
 

--- a/src/components/number-field/NumberField.classes.ts
+++ b/src/components/number-field/NumberField.classes.ts
@@ -1,0 +1,27 @@
+export const CLASSES = {
+  Root: {
+    base: "number-field",
+    variant: {
+      primary: "number-field--primary",
+      secondary: "number-field--secondary",
+    },
+    flag: {
+      fullWidth: "number-field--full-width",
+    },
+  },
+  Group: {
+    base: "number-field__group",
+    flag: {
+      fullWidth: "number-field__group--full-width",
+    },
+  },
+  Input: {
+    base: "number-field__input",
+  },
+  IncrementButton: {
+    base: "number-field__increment-button",
+  },
+  DecrementButton: {
+    base: "number-field__decrement-button",
+  },
+} as const;

--- a/src/components/number-field/NumberField.tsx
+++ b/src/components/number-field/NumberField.tsx
@@ -13,13 +13,9 @@ import {
 import { twMerge } from "tailwind-merge";
 
 import type { IComponentBaseProps } from "../types";
+import { CLASSES } from "./NumberField.classes";
 
 export type NumberFieldVariant = "primary" | "secondary";
-
-const VARIANT_CLASS_MAP: Record<NumberFieldVariant, string> = {
-  primary: "number-field--primary",
-  secondary: "number-field--secondary",
-};
 
 type NumberFieldContextValue = {
   valueText: Accessor<string>;
@@ -229,9 +225,9 @@ const NumberFieldRoot: ParentComponent<NumberFieldRootProps> = (props) => {
       <div
         {...others}
         class={twMerge(
-          "number-field",
-          VARIANT_CLASS_MAP[variant()],
-          fullWidth() && "number-field--full-width",
+          CLASSES.Root.base,
+          CLASSES.Root.variant[variant()],
+          fullWidth() && CLASSES.Root.flag.fullWidth,
           local.class,
           local.className,
         )}
@@ -273,8 +269,8 @@ const NumberFieldGroup: ParentComponent<NumberFieldGroupProps> = (props) => {
     <div
       {...others}
       class={twMerge(
-        "number-field__group",
-        context?.fullWidth() && "number-field__group--full-width",
+        CLASSES.Group.base,
+        context?.fullWidth() && CLASSES.Group.flag.fullWidth,
         local.class,
         local.className,
       )}
@@ -317,7 +313,7 @@ const NumberFieldInput: Component<NumberFieldInputProps> = (props) => {
       {...others}
       type="text"
       inputmode="decimal"
-      class={twMerge("number-field__input", local.class, local.className)}
+      class={twMerge(CLASSES.Input.base, local.class, local.className)}
       data-slot="number-field-input"
       data-theme={local.dataTheme}
       style={local.style}
@@ -349,7 +345,7 @@ const NumberFieldIncrementButton: Component<NumberFieldIncrementButtonProps> = (
     <button
       {...others}
       type="button"
-      class={twMerge("number-field__increment-button", local.class, local.className)}
+      class={twMerge(CLASSES.IncrementButton.base, local.class, local.className)}
       data-slot="number-field-increment-button"
       data-theme={local.dataTheme}
       style={local.style}
@@ -390,7 +386,7 @@ const NumberFieldDecrementButton: Component<NumberFieldDecrementButtonProps> = (
     <button
       {...others}
       type="button"
-      class={twMerge("number-field__decrement-button", local.class, local.className)}
+      class={twMerge(CLASSES.DecrementButton.base, local.class, local.className)}
       data-slot="number-field-decrement-button"
       data-theme={local.dataTheme}
       style={local.style}

--- a/src/components/search-field/SearchField.classes.ts
+++ b/src/components/search-field/SearchField.classes.ts
@@ -1,0 +1,27 @@
+export const CLASSES = {
+  Root: {
+    base: "search-field",
+    variant: {
+      primary: "search-field--primary",
+      secondary: "search-field--secondary",
+    },
+    flag: {
+      fullWidth: "search-field--full-width",
+    },
+  },
+  Group: {
+    base: "search-field__group",
+    flag: {
+      fullWidth: "search-field__group--full-width",
+    },
+  },
+  Input: {
+    base: "search-field__input",
+  },
+  SearchIcon: {
+    base: "search-field__search-icon",
+  },
+  ClearButton: {
+    base: "search-field__clear-button",
+  },
+} as const;

--- a/src/components/search-field/SearchField.tsx
+++ b/src/components/search-field/SearchField.tsx
@@ -14,13 +14,9 @@ import { twMerge } from "tailwind-merge";
 
 import CloseButton, { type CloseButtonProps } from "../close-button";
 import type { IComponentBaseProps } from "../types";
+import { CLASSES } from "./SearchField.classes";
 
 export type SearchFieldVariant = "primary" | "secondary";
-
-const VARIANT_CLASS_MAP: Record<SearchFieldVariant, string> = {
-  primary: "search-field--primary",
-  secondary: "search-field--secondary",
-};
 
 type SearchFieldContextValue = {
   value: Accessor<string>;
@@ -156,9 +152,9 @@ const SearchFieldRoot: ParentComponent<SearchFieldRootProps> = (props) => {
       <div
         {...others}
         class={twMerge(
-          "search-field",
-          VARIANT_CLASS_MAP[variant()],
-          fullWidth() && "search-field--full-width",
+          CLASSES.Root.base,
+          CLASSES.Root.variant[variant()],
+          fullWidth() && CLASSES.Root.flag.fullWidth,
           local.class,
           local.className,
         )}
@@ -206,8 +202,8 @@ const SearchFieldGroup: ParentComponent<SearchFieldGroupProps> = (props) => {
     <div
       {...others}
       class={twMerge(
-        "search-field__group",
-        context?.fullWidth() && "search-field__group--full-width",
+        CLASSES.Group.base,
+        context?.fullWidth() && CLASSES.Group.flag.fullWidth,
         local.class,
         local.className,
       )}
@@ -249,7 +245,7 @@ const SearchFieldInput: Component<SearchFieldInputProps> = (props) => {
     <input
       {...others}
       type="search"
-      class={twMerge("search-field__input", local.class, local.className)}
+      class={twMerge(CLASSES.Input.base, local.class, local.className)}
       data-slot="search-field-input"
       data-theme={local.dataTheme}
       style={local.style}
@@ -272,7 +268,7 @@ const SearchFieldSearchIcon: Component<SearchFieldSearchIconProps> = (props) => 
   return (
     <span
       {...others}
-      class={twMerge("search-field__search-icon", local.class, local.className)}
+      class={twMerge(CLASSES.SearchIcon.base, local.class, local.className)}
       data-slot="search-field-search-icon"
       data-theme={local.dataTheme}
       style={local.style}
@@ -298,7 +294,7 @@ const SearchFieldClearButton: Component<SearchFieldClearButtonProps> = (props) =
   return (
     <CloseButton
       {...others}
-      class={twMerge("search-field__clear-button", local.class, local.className)}
+      class={twMerge(CLASSES.ClearButton.base, local.class, local.className)}
       data-slot="search-field-clear-button"
       data-theme={local.dataTheme}
       style={local.style}

--- a/src/components/separator/Separator.classes.ts
+++ b/src/components/separator/Separator.classes.ts
@@ -1,0 +1,12 @@
+export const CLASSES = {
+  base: "separator",
+  orientation: {
+    horizontal: "separator--horizontal",
+    vertical: "separator--vertical",
+  },
+  variant: {
+    default: "separator--default",
+    secondary: "separator--secondary",
+    tertiary: "separator--tertiary",
+  },
+} as const;

--- a/src/components/separator/Separator.tsx
+++ b/src/components/separator/Separator.tsx
@@ -3,20 +3,10 @@ import { splitProps, type Component, type JSX } from "solid-js";
 import { twMerge } from "tailwind-merge";
 
 import type { IComponentBaseProps } from "../types";
+import { CLASSES } from "./Separator.classes";
 
 export type SeparatorOrientation = "horizontal" | "vertical";
 export type SeparatorVariant = "default" | "secondary" | "tertiary";
-
-const ORIENTATION_CLASS: Record<SeparatorOrientation, string> = {
-  horizontal: "separator--horizontal",
-  vertical: "separator--vertical",
-};
-
-const VARIANT_CLASS: Record<SeparatorVariant, string> = {
-  default: "separator--default",
-  secondary: "separator--secondary",
-  tertiary: "separator--tertiary",
-};
 
 export type SeparatorProps = Omit<JSX.HTMLAttributes<HTMLDivElement>, "children"> &
   IComponentBaseProps & {
@@ -47,9 +37,9 @@ const Separator: Component<SeparatorProps> = (props) => {
       data-orientation={orientation()}
       data-variant={variant()}
       class={twMerge(
-        "separator",
-        ORIENTATION_CLASS[orientation()],
-        VARIANT_CLASS[variant()],
+        CLASSES.base,
+        CLASSES.orientation[orientation()],
+        CLASSES.variant[variant()],
         local.class,
         local.className,
       )}

--- a/src/components/surface/Surface.classes.ts
+++ b/src/components/surface/Surface.classes.ts
@@ -1,0 +1,9 @@
+export const CLASSES = {
+  base: "surface",
+  variant: {
+    default: "surface--default",
+    secondary: "surface--secondary",
+    tertiary: "surface--tertiary",
+    transparent: "surface--transparent",
+  },
+} as const;

--- a/src/components/surface/Surface.tsx
+++ b/src/components/surface/Surface.tsx
@@ -3,18 +3,12 @@ import { splitProps, type JSX } from "solid-js";
 import { twMerge } from "tailwind-merge";
 
 import type { IComponentBaseProps } from "../types";
+import { CLASSES } from "./Surface.classes";
 
 export type SurfaceVariant = "default" | "secondary" | "tertiary" | "transparent";
 
 export type SurfaceVariants = {
   variant?: SurfaceVariant;
-};
-
-const SURFACE_VARIANT_CLASS: Record<SurfaceVariant, string> = {
-  default: "surface--default",
-  secondary: "surface--secondary",
-  tertiary: "surface--tertiary",
-  transparent: "surface--transparent",
 };
 
 export type SurfaceProps = Omit<JSX.HTMLAttributes<HTMLDivElement>, "children"> &
@@ -38,7 +32,7 @@ export function Surface(props: SurfaceProps) {
   return (
     <div
       {...others}
-      class={twMerge("surface", SURFACE_VARIANT_CLASS[variant()], local.class, local.className)}
+      class={twMerge(CLASSES.base, CLASSES.variant[variant()], local.class, local.className)}
       data-slot="surface"
       data-theme={local.dataTheme}
       style={local.style}

--- a/src/components/tag-group/TagGroup.classes.ts
+++ b/src/components/tag-group/TagGroup.classes.ts
@@ -1,0 +1,8 @@
+export const CLASSES = {
+  Root: {
+    base: "tag-group",
+  },
+  List: {
+    base: "tag-group__list",
+  },
+} as const;

--- a/src/components/tag-group/TagGroup.tsx
+++ b/src/components/tag-group/TagGroup.tsx
@@ -13,6 +13,7 @@ import { twMerge } from "tailwind-merge";
 
 import type { IComponentBaseProps } from "../types";
 import type { TagSize, TagVariant } from "../tag";
+import { CLASSES } from "./TagGroup.classes";
 import { TagGroupContext, type TagSelectionMode } from "./context";
 
 const normalizeKeys = (keys?: Iterable<string | number>): Set<string> => {
@@ -142,7 +143,7 @@ const TagGroupRoot: ParentComponent<TagGroupRootProps> = (props) => {
         data-selection-mode={selectionMode()}
         data-disabled={isDisabled() ? "true" : "false"}
         aria-disabled={isDisabled() ? "true" : undefined}
-        class={twMerge("tag-group", local.class, local.className)}
+        class={twMerge(CLASSES.Root.base, local.class, local.className)}
         style={local.style}
       >
         {local.children}
@@ -188,7 +189,7 @@ const TagGroupList: Component<TagGroupListProps> = (props) => {
       aria-multiselectable={group?.selectionMode() === "multiple" ? "true" : undefined}
       data-slot="tag-group-list"
       data-theme={local.dataTheme}
-      class={twMerge("tag-group__list", local.class, local.className)}
+      class={twMerge(CLASSES.List.base, local.class, local.className)}
       style={local.style}
     >
       {renderChildren()}

--- a/src/components/tag/Tag.classes.ts
+++ b/src/components/tag/Tag.classes.ts
@@ -1,0 +1,20 @@
+export const CLASSES = {
+  Root: {
+    base: "tag",
+    size: {
+      sm: "tag--sm",
+      md: "tag--md",
+      lg: "tag--lg",
+    },
+    variant: {
+      default: "tag--default",
+      surface: "tag--surface",
+    },
+  },
+  slot: {
+    icon: "tag__icon",
+    iconStart: "tag__icon--start",
+    iconEnd: "tag__icon--end",
+    removeButton: "tag__remove-button",
+  },
+} as const;

--- a/src/components/tag/Tag.tsx
+++ b/src/components/tag/Tag.tsx
@@ -16,6 +16,7 @@ import { twMerge } from "tailwind-merge";
 import CloseButton, { type CloseButtonProps } from "../close-button";
 import type { IComponentBaseProps } from "../types";
 import { TagGroupContext } from "../tag-group/context";
+import { CLASSES } from "./Tag.classes";
 
 const invokeEventHandler = (handler: unknown, event: Event) => {
   if (typeof handler === "function") {
@@ -50,17 +51,6 @@ type TagRenderProps = {
   isSelected: boolean;
   isDisabled: boolean;
   allowsRemoving: boolean;
-};
-
-const TAG_SIZE_CLASS_MAP: Record<TagSize, string> = {
-  sm: "tag--sm",
-  md: "tag--md",
-  lg: "tag--lg",
-};
-
-const TAG_VARIANT_CLASS_MAP: Record<TagVariant, string> = {
-  default: "tag--default",
-  surface: "tag--surface",
 };
 
 type TagContextValue = {
@@ -180,9 +170,9 @@ const TagRoot: ParentComponent<TagRootProps> = (props) => {
       <div
         {...others}
         class={twMerge(
-          "tag",
-          TAG_SIZE_CLASS_MAP[size()],
-          TAG_VARIANT_CLASS_MAP[variant()],
+          CLASSES.Root.base,
+          CLASSES.Root.size[size()],
+          CLASSES.Root.variant[variant()],
           local.class,
           local.className,
         )}
@@ -206,7 +196,10 @@ const TagRoot: ParentComponent<TagRootProps> = (props) => {
           fallback={
             <>
               <Show when={local.startIcon}>
-                <span class="tag__icon tag__icon--start" data-slot="tag-start-icon">
+                <span
+                  class={twMerge(CLASSES.slot.icon, CLASSES.slot.iconStart)}
+                  data-slot="tag-start-icon"
+                >
                   {local.startIcon}
                 </span>
               </Show>
@@ -215,7 +208,10 @@ const TagRoot: ParentComponent<TagRootProps> = (props) => {
                 <TagRemoveButton>{local.endIcon}</TagRemoveButton>
               </Show>
               <Show when={!allowsRemoving() && local.endIcon}>
-                <span class="tag__icon tag__icon--end" data-slot="tag-end-icon">
+                <span
+                  class={twMerge(CLASSES.slot.icon, CLASSES.slot.iconEnd)}
+                  data-slot="tag-end-icon"
+                >
                   {local.endIcon}
                 </span>
               </Show>
@@ -260,7 +256,7 @@ const TagRemoveButton: Component<TagRemoveButtonProps> = (props) => {
     <CloseButton
       {...others}
       aria-label={local["aria-label"] ?? "Remove tag"}
-      class={twMerge("tag__remove-button", local.class, local.className)}
+      class={twMerge(CLASSES.slot.removeButton, local.class, local.className)}
       data-slot="tag-remove-button"
       data-theme={local.dataTheme}
       style={local.style}

--- a/src/components/text-area/TextArea.classes.ts
+++ b/src/components/text-area/TextArea.classes.ts
@@ -1,0 +1,10 @@
+export const CLASSES = {
+  base: "textarea",
+  variant: {
+    primary: "textarea--primary",
+    secondary: "textarea--secondary",
+  },
+  flag: {
+    fullWidth: "textarea--full-width",
+  },
+} as const;

--- a/src/components/text-area/TextArea.tsx
+++ b/src/components/text-area/TextArea.tsx
@@ -4,13 +4,9 @@ import { twMerge } from "tailwind-merge";
 
 import { useTextFieldContext, type TextFieldVariant } from "../text-field";
 import type { IComponentBaseProps } from "../types";
+import { CLASSES } from "./TextArea.classes";
 
 export type TextAreaVariant = TextFieldVariant;
-
-const VARIANT_CLASS_MAP: Record<TextAreaVariant, string> = {
-  primary: "textarea--primary",
-  secondary: "textarea--secondary",
-};
 
 export type TextAreaRootProps = Omit<JSX.TextareaHTMLAttributes<HTMLTextAreaElement>, "children"> &
   IComponentBaseProps & {
@@ -44,9 +40,9 @@ const TextAreaRoot: Component<TextAreaRootProps> = (props) => {
     <textarea
       {...others}
       class={twMerge(
-        "textarea",
-        VARIANT_CLASS_MAP[variant()],
-        fullWidth() && "textarea--full-width",
+        CLASSES.base,
+        CLASSES.variant[variant()],
+        fullWidth() && CLASSES.flag.fullWidth,
         local.class,
         local.className,
       )}

--- a/src/components/text-field/TextField.classes.ts
+++ b/src/components/text-field/TextField.classes.ts
@@ -1,0 +1,10 @@
+export const CLASSES = {
+  base: "text-field",
+  variant: {
+    primary: "text-field--primary",
+    secondary: "text-field--secondary",
+  },
+  flag: {
+    fullWidth: "text-field--full-width",
+  },
+} as const;

--- a/src/components/text-field/TextField.tsx
+++ b/src/components/text-field/TextField.tsx
@@ -10,13 +10,9 @@ import {
 import { twMerge } from "tailwind-merge";
 
 import type { IComponentBaseProps } from "../types";
+import { CLASSES } from "./TextField.classes";
 
 export type TextFieldVariant = "primary" | "secondary";
-
-const VARIANT_CLASS_MAP: Record<TextFieldVariant, string> = {
-  primary: "text-field--primary",
-  secondary: "text-field--secondary",
-};
 
 export type TextFieldRenderProps = {
   isInvalid: boolean;
@@ -83,9 +79,9 @@ const TextFieldRoot: Component<TextFieldRootProps> = (props) => {
       <div
         {...others}
         class={twMerge(
-          "text-field",
-          VARIANT_CLASS_MAP[variant()],
-          fullWidth() && "text-field--full-width",
+          CLASSES.base,
+          CLASSES.variant[variant()],
+          fullWidth() && CLASSES.flag.fullWidth,
           local.class,
           local.className,
         )}

--- a/src/components/text/Text.classes.ts
+++ b/src/components/text/Text.classes.ts
@@ -1,0 +1,3 @@
+export const CLASSES = {
+  base: "text",
+} as const;

--- a/src/components/text/Text.tsx
+++ b/src/components/text/Text.tsx
@@ -3,6 +3,7 @@ import { splitProps, type Component, type JSX } from "solid-js";
 import { twMerge } from "tailwind-merge";
 
 import type { IComponentBaseProps } from "../types";
+import { CLASSES } from "./Text.classes";
 
 export type TextSize = "xs" | "sm" | "base" | "lg" | "xl";
 export type TextVariant = "default" | "muted" | "success" | "warning" | "danger";
@@ -31,7 +32,7 @@ const TextRoot: Component<TextRootProps> = (props) => {
   return (
     <span
       {...others}
-      class={twMerge("text", local.class, local.className)}
+      class={twMerge(CLASSES.base, local.class, local.className)}
       data-slot="text"
       data-size={size()}
       data-variant={variant()}

--- a/src/components/time-field/TimeField.classes.ts
+++ b/src/components/time-field/TimeField.classes.ts
@@ -1,0 +1,37 @@
+export const CLASSES = {
+  Root: {
+    base: "time-field",
+    variant: {
+      primary: "time-field--primary",
+      secondary: "time-field--secondary",
+    },
+    flag: {
+      fullWidth: "time-field--full-width",
+    },
+  },
+  Group: {
+    base: "date-input-group",
+    variant: {
+      primary: "date-input-group--primary",
+      secondary: "date-input-group--secondary",
+    },
+    flag: {
+      fullWidth: "date-input-group--full-width",
+    },
+  },
+  Input: {
+    base: "date-input-group__input",
+  },
+  InputContainer: {
+    base: "date-input-group__input-container",
+  },
+  Segment: {
+    base: "date-input-group__segment",
+  },
+  Prefix: {
+    base: "date-input-group__prefix",
+  },
+  Suffix: {
+    base: "date-input-group__suffix",
+  },
+} as const;

--- a/src/components/time-field/TimeField.tsx
+++ b/src/components/time-field/TimeField.tsx
@@ -12,18 +12,9 @@ import {
 import { twMerge } from "tailwind-merge";
 
 import type { IComponentBaseProps } from "../types";
+import { CLASSES } from "./TimeField.classes";
 
 export type TimeFieldVariant = "primary" | "secondary";
-
-const VARIANT_CLASS_MAP: Record<TimeFieldVariant, string> = {
-  primary: "time-field--primary",
-  secondary: "time-field--secondary",
-};
-
-const GROUP_VARIANT_CLASS_MAP: Record<TimeFieldVariant, string> = {
-  primary: "date-input-group--primary",
-  secondary: "date-input-group--secondary",
-};
 
 type TimeFieldContextValue = {
   value: Accessor<string>;
@@ -168,9 +159,9 @@ const TimeFieldRoot: ParentComponent<TimeFieldRootProps> = (props) => {
       <div
         {...others}
         class={twMerge(
-          "time-field",
-          VARIANT_CLASS_MAP[variant()],
-          fullWidth() && "time-field--full-width",
+          CLASSES.Root.base,
+          CLASSES.Root.variant[variant()],
+          fullWidth() && CLASSES.Root.flag.fullWidth,
           local.class,
           local.className,
         )}
@@ -212,9 +203,9 @@ const TimeFieldGroup: ParentComponent<TimeFieldGroupProps> = (props) => {
     <div
       {...others}
       class={twMerge(
-        "date-input-group",
-        GROUP_VARIANT_CLASS_MAP[context?.variant() ?? "primary"],
-        context?.fullWidth() && "date-input-group--full-width",
+        CLASSES.Group.base,
+        CLASSES.Group.variant[context?.variant() ?? "primary"],
+        context?.fullWidth() && CLASSES.Group.flag.fullWidth,
         local.class,
         local.className,
       )}
@@ -256,7 +247,7 @@ const TimeFieldInput: Component<TimeFieldInputProps> = (props) => {
     <input
       {...others}
       type="time"
-      class={twMerge("date-input-group__input", local.class, local.className)}
+      class={twMerge(CLASSES.Input.base, local.class, local.className)}
       data-slot="date-input-group-input"
       data-theme={local.dataTheme}
       style={local.style}
@@ -278,7 +269,7 @@ const TimeFieldInputContainer: ParentComponent<TimeFieldInputContainerProps> = (
   return (
     <div
       {...others}
-      class={twMerge("date-input-group__input-container", local.class, local.className)}
+      class={twMerge(CLASSES.InputContainer.base, local.class, local.className)}
       data-slot="date-input-group-input-container"
       data-theme={local.dataTheme}
       style={local.style}
@@ -301,7 +292,7 @@ const TimeFieldSegment: ParentComponent<TimeFieldSegmentProps> = (props) => {
   return (
     <span
       {...others}
-      class={twMerge("date-input-group__segment", local.class, local.className)}
+      class={twMerge(CLASSES.Segment.base, local.class, local.className)}
       data-slot="date-input-group-segment"
       data-type={local.segment?.type}
       data-placeholder={local.segment?.isPlaceholder ? "true" : undefined}
@@ -322,7 +313,7 @@ const TimeFieldPrefix: ParentComponent<TimeFieldPrefixProps> = (props) => {
   return (
     <div
       {...others}
-      class={twMerge("date-input-group__prefix", local.class, local.className)}
+      class={twMerge(CLASSES.Prefix.base, local.class, local.className)}
       data-slot="date-input-group-prefix"
       data-theme={local.dataTheme}
       style={local.style}
@@ -338,7 +329,7 @@ const TimeFieldSuffix: ParentComponent<TimeFieldSuffixProps> = (props) => {
   return (
     <div
       {...others}
-      class={twMerge("date-input-group__suffix", local.class, local.className)}
+      class={twMerge(CLASSES.Suffix.base, local.class, local.className)}
       data-slot="date-input-group-suffix"
       data-theme={local.dataTheme}
       style={local.style}


### PR DESCRIPTION
Adds a `<ComponentName>.classes.ts` file next to each component .tsx, with a single exported `CLASSES` const literal that holds every CSS class the component can render. The component imports the const and references every class through `CLASSES.*` — no class strings live in the .tsx file anymore.

This is the authoring-side groundwork for the upcoming css-purge plugin (the port of @pathscale/rollup-plugin-vue3-ui-css-purge to the new stack). The analyzer reads each .classes.ts file directly as data — no JSX parsing, no clsx/twMerge inspection, no conditional reasoning — and uses the result as the per-component database the plugin's safelist is built from.

Three example components are included to cover the common shapes:

- button/         single component, slots base + variant + size + flag
- breadcrumbs/    compound (Root + Item) in one file, base as array
- navbar/         compound across 4 files with one shared classes.ts;
                  exercises base (string and array), variant, flag, and a
                  new color slot for ComponentColor

Slot reference (uniform across components):
  base     always rendered (string or readonly string[])
  variant  enum prop value -> class
  size     same shape, conventional name for the size prop
  flag     boolean prop NAME -> class (rendered when prop is truthy)
  color    enum prop value -> class (used for ComponentColor)

New slot names are allowed when a component needs them; the analyzer treats every nested object identically.

Where it makes sense, types are derived from the const so they cannot drift from the class map:
  export type ButtonVariant = keyof typeof CLASSES.variant;

No consumer-facing API changes for any of the three components. Verified with `bunx tsc --noEmit` (clean) and `bun run build` (all .classes.js + .classes.d.ts artifacts produced in dist/).

Diego: copy the shape from these three examples for the rest of the lib. The inviolable rule is "no class strings outside the .classes.ts file".