### PR TITLE
fix: remove stale stores export

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,10 +39,6 @@
       "types": "./dist/hooks/*/index.d.ts",
       "import": "./dist/hooks/*/index.js"
     },
-    "./stores": {
-      "types": "./dist/stores/index.d.ts",
-      "import": "./dist/stores/index.js"
-    },
     "./motion": {
       "types": "./dist/motion/index.d.ts",
       "import": "./dist/motion/index.js"


### PR DESCRIPTION
## Summary

Remove the stale `./stores` package export. The published `@pathscale/ui@1.2.11` package advertises:

```json
"./stores": {
  "types": "./dist/stores/index.d.ts",
  "import": "./dist/stores/index.js"
}
```

but the npm tarball does not include `dist/stores/index.d.ts` or `dist/stores/index.js`, and the current source tree does not include a `src/stores` entrypoint.

## Reproduction

```sh
TMP=$(mktemp -d)
cd "$TMP"
npm pack @pathscale/ui@1.2.11 --ignore-scripts --json
TGZ=$(ls pathscale-ui-*.tgz | head -n 1)
tar -xzf "$TGZ"
node - <<'NODE'
const fs = require('fs')
const p = require('./package/package.json')
console.log(p.exports['./stores'])
console.log('stores js', fs.existsSync('./package/dist/stores/index.js'))
console.log('stores dts', fs.existsSync('./package/dist/stores/index.d.ts'))
NODE
```

Current output shows the export exists, but both target files are missing.

## Validation

- Verified the current source tree has `src/components`, `src/hooks`, `src/lib`, `src/motion`, `src/primitives`, and `src/styles`, but no `src/stores` entrypoint.
- Searched for `@pathscale/ui/stores`, `src/stores`, `"./stores"`, and `dist/stores` references after the patch.
- Parsed `package.json` and confirmed `exports["./stores"]` is removed.
- Did not run package install/build scripts.
